### PR TITLE
[DCS] References GA version of service

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Give it a try! Click the button below to fork into IBM DevOps Services and deplo
 
 5. Create the Document Conversion service in Bluemix
   ```sh
-  $ cf create-service document_conversion experimental document-conversion-service
+  $ cf create-service document_conversion standard document-conversion-service
   ```
 
 6. Push it live!
@@ -67,7 +67,7 @@ Give it a try! Click the button below to fork into IBM DevOps Services and deplo
           },
         "label": "document_conversion",
         "name": "document-conversion-service",
-        "plan": "experimental"
+        "plan": "standard"
      }]
     }
     }

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ require('./config/express')(app);
 var credentials = {
   username: '<username>',
   password: '<password>',
-  version: 'v1-experimental'
+  version: 'v1'
 };
 
 var document_conversion = watson.document_conversion(credentials);

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 declared-services:
   document-conversion-service:
     label: document_conversion
-    plan: experimental
+    plan: standard
 applications:
 - services:
   - document-conversion-service


### PR DESCRIPTION
This commit updates the demo to use the
standard GA version of the document
conversion service instead of experimental.
